### PR TITLE
CE git log grafika i opis

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ body{
 	<li>
 		<strong>git log --graph --all</strong> - <span>wyświetla graficzną (choć tekstową) reprezentację historii wszystkich commitów w repozytorium</span>
 		<br><figure><a href="http://i.imgur.com/8iLX0jS.png"><img src="http://i.imgur.com/8iLX0jS.png" title="git log w git bash" alt="Zachowanie komendy git log --graph -all w git bash" style='height: 25%; width: 25%; object-fit: cover'></a>
-		<figcaption>Działanie komendy w git bash (graficzna reprezentacja commitów)</figcaption </figure>
+		<figcaption>Działanie komendy w git bash (graficzna reprezentacja commitów)</figcaption> </figure>
 	</li>
 	<li>
 		<strong>git branch -d "branch"</strong> - <span>usuwa gałąź "branch"</span>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@ body{
 	</li>
 	<li>
 		<strong>git log --graph --all</strong> - <span>wyświetla graficzną (choć tekstową) reprezentację historii wszystkich commitów w repozytorium</span>
+		<br><figure><a href="http://i.imgur.com/8iLX0jS.png"><img src="http://i.imgur.com/8iLX0jS.png" title="git log w git bash" alt="Zachowanie komendy git log --graph -all w git bash" style='height: 25%; width: 25%; object-fit: cover'></a>
+		<figcaption>Działanie komendy w git bash (graficzna reprezentacja commitów)</figcaption </figure>
 	</li>
 	<li>
 		<strong>git branch -d "branch"</strong> - <span>usuwa gałąź "branch"</span>


### PR DESCRIPTION
Screenshot z git log w działaniu w git bash (shell).
Zawiera link i podpis obrazu, zmienia rozmiar w zależności od rozmiaru okna przeglądarki.